### PR TITLE
Optional service account reference

### DIFF
--- a/charts/externalSecret-ClusterStore/Chart.yaml
+++ b/charts/externalSecret-ClusterStore/Chart.yaml
@@ -5,10 +5,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.24.2"
+appVersion: "0.2.0"

--- a/charts/externalSecret-ClusterStore/templates/clusterSecretStore.yaml
+++ b/charts/externalSecret-ClusterStore/templates/clusterSecretStore.yaml
@@ -23,10 +23,12 @@ spec:
         kubernetes:
           mountPath: {{ .Values.vault_auth_path }}
           role: {{ .Values.vault_role }}
+          {{- if .Values.saReference -}}
           # Optional service account reference
           serviceAccountRef:
             name: {{ .Values.k8s_sa }}
             namespace: {{ .Values.namespace }}
+          {{- end -}}
           # Optional secret field containing a Kubernetes ServiceAccount JWT
           # used for authenticating with Vault
           secretRef:

--- a/charts/externalSecret-ClusterStore/values.yaml
+++ b/charts/externalSecret-ClusterStore/values.yaml
@@ -1,3 +1,4 @@
+saReference: true
 namespace: ""
 vault_server: ""
 vault_kv_path: ""


### PR DESCRIPTION
On some cases, this block cause failures in crewating secret store
- Add a variable set to tru by default, so normal working behaviour will be same
- If set to false during runtime, it will not create a "serviceAccountRef" block
- Bumped up chart version and sync app version to chart version as we do not deploy any app with this chart