### PR TITLE
Fix/istio monitoring

### DIFF
--- a/charts/grafana-agent/CHANGELOG.md
+++ b/charts/grafana-agent/CHANGELOG.md
@@ -33,6 +33,14 @@ are not present.
 
 ## Changes
 
+### v3.1.3 (2023-04-04 - Suleyman Kutlu)
+
+-----------------
+
+#### Bugfixes
+
+- Istio Envoy Stats monitoring uses hard coded port number to scrape metrics. It should use the port defioned in pod annotations, instead.
+
 ### v3.1.2 (2023-04-04 - Suleyman Kutlu)
 
 -----------------

--- a/charts/grafana-agent/Chart.yaml
+++ b/charts/grafana-agent/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.2
+version: 3.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/grafana-agent/templates/_stateful_jobs_helper.tpl
+++ b/charts/grafana-agent/templates/_stateful_jobs_helper.tpl
@@ -316,7 +316,7 @@ Statefulset service job definitions
   - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
     action: replace
     regex: ([^:]+)(?::\d+)?;(\d+)
-    replacement: $1:15090
+    replacement: $1:$2
     target_label: __address__
   - action: labeldrop
     regex: __meta_kubernetes_pod_label_(.+)


### PR DESCRIPTION
Istio Envoy Stats monitoring definition uses hard coded port to scrape metrics from pods. It should use whatever port defined in pod annotations.